### PR TITLE
Fix Bug In Location Feature

### DIFF
--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -16,7 +16,6 @@ import 'package:groceries_app/core/network/dio_factory.dart';
 import 'package:groceries_app/core/network/favorites/favorite_api_service.dart';
 import 'package:groceries_app/core/network/products/product_api_service.dart';
 import 'package:groceries_app/core/utils/app_preferences.dart';
-import 'package:groceries_app/core/utils/enums.dart';
 import 'package:groceries_app/features/auth/data/api/auth_api_service.dart';
 import 'package:groceries_app/features/auth/data/data_source/auth_data_source.dart';
 import 'package:groceries_app/features/auth/data/repo/auth_repository_impl.dart';

--- a/lib/core/di/di.main.dart
+++ b/lib/core/di/di.main.dart
@@ -38,7 +38,7 @@ initPhoneAuthDi() async {
   }
 }
 
-initLocationDi(LocationPurpose purpose) async {
+initLocationDi() async {
   if (!getIt.isRegistered<LocationCubit>()) {
     getIt
       ..registerLazySingleton<LocationApiService>(
@@ -57,8 +57,16 @@ initLocationDi(LocationPurpose purpose) async {
           () => GetPlaceDetailsUseCase(getIt()))
       ..registerLazySingleton<UpdateUserAddressUseCase>(
           () => UpdateUserAddressUseCase(getIt()))
-      ..registerFactory<LocationCubit>(
-          () => LocationCubit(getIt(), getIt(), getIt(), getIt(), purpose));
+      ..registerLazySingleton<LocationCubit>(
+          () => LocationCubit(getIt(), getIt(), getIt(), getIt()));
+  } else {
+    final state = getIt<LocationCubit>().state;
+    if (state is! GetPositionSuccess) {
+      getIt.unregister<LocationCubit>(
+          disposingFunction: (cubit) => cubit.isClosed ? null : cubit.close());
+      getIt.registerLazySingleton<LocationCubit>(
+          () => LocationCubit(getIt(), getIt(), getIt(), getIt()));
+    }
   }
 }
 

--- a/lib/core/routes/routes_manager.main.dart
+++ b/lib/core/routes/routes_manager.main.dart
@@ -99,9 +99,9 @@ abstract class RouteGenerator {
         path: Routes.locationRoute,
         builder: (context, state) {
           final purpose = state.extra as LocationPurpose;
-          initLocationDi(purpose);
+          initLocationDi();
           return BlocProvider<LocationCubit>(
-              create: (context) => getIt<LocationCubit>(),
+              create: (context) => getIt<LocationCubit>()..setPurpose(purpose),
               child: const SelectLocationView());
         },
       ),

--- a/lib/features/checkout/presentation/cubit/confirm_payment_cubit.dart
+++ b/lib/features/checkout/presentation/cubit/confirm_payment_cubit.dart
@@ -45,8 +45,6 @@ class ConfirmPaymentCubit extends Cubit<ConfirmPaymentState> {
     return uri.queryParameters;
   }
 
-
-
   PaymentUrlType getUrlType() {
     final queryParameters = _getQueryParameters();
     final isRedirect = queryParameters.containsKey('payment_token') &&

--- a/lib/features/location/presentation/cubit/location_cubit.dart
+++ b/lib/features/location/presentation/cubit/location_cubit.dart
@@ -19,14 +19,15 @@ class LocationCubit extends Cubit<LocationState> {
     this._suggestedPlacesUseCase,
     this._placeDetailsUseCase,
     this._updateUserAddressUseCase,
-    this._purpose,
   ) : super(LocationInitial());
 
   final GetPlaceFromCoordinatesUseCase _placeFromCoordinatesUseCase;
   final GetSuggestedPlacesUseCase _suggestedPlacesUseCase;
   final GetPlaceDetailsUseCase _placeDetailsUseCase;
   final UpdateUserAddressUseCase _updateUserAddressUseCase;
-  final LocationPurpose _purpose;
+  late final LocationPurpose _purpose;
+
+  void setPurpose(LocationPurpose purpose) => _purpose = purpose;
 
   LocationPurpose get purpose => _purpose;
 

--- a/lib/features/location/presentation/views/select_location_view.dart
+++ b/lib/features/location/presentation/views/select_location_view.dart
@@ -16,23 +16,24 @@ class SelectLocationView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return LocationViewListener(
-      child:
-          BlocBuilder<LocationCubit, LocationState>(builder: (context, state) {
-        final cubit = context.read<LocationCubit>();
-        return Scaffold(
-          appBar: AppBar(
-            actions: cubit.purpose == LocationPurpose.newAccount
-                ? [SkipTextButton(onPressed: () {})]
-                : [],
-            title: const Text(
-              AppStrings.location,
-              style: StylesManager.bold24,
+      child: BlocBuilder<LocationCubit, LocationState>(
+        builder: (context, state) {
+          final cubit = context.read<LocationCubit>();
+          return Scaffold(
+            appBar: AppBar(
+              actions: cubit.purpose == LocationPurpose.newAccount
+                  ? [SkipTextButton(onPressed: () {})]
+                  : [],
+              title: const Text(
+                AppStrings.location,
+                style: StylesManager.bold24,
+              ),
+              leading: context.canPop() ? const CustomBackButton() : null,
             ),
-            leading: context.canPop() ? const CustomBackButton() : null,
-          ),
-          body: const SelectLocationViewBody(),
-        );
-      }),
+            body: const SelectLocationViewBody(),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/features/location/presentation/widgets/map_view_body.dart
+++ b/lib/features/location/presentation/widgets/map_view_body.dart
@@ -18,19 +18,25 @@ class _MapViewBodyState extends State<MapViewBody> {
   late final GoogleMapController _mapController;
 
   @override
+  void initState() {
+    super.initState();
+
+    final position = context.read<LocationCubit>().state;
+    if (position is GetPositionSuccess) {
+      _setLatLng(position.position.latitude, position.position.longitude);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return BlocListener<LocationCubit, LocationState>(
       listener: (context, state) {
-        if (state is GetPositionSuccess) {
-          _setLatLng(state.position.latitude, state.position.longitude);
-        }
-
         if (state is GetPlaceDetailsSuccess) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             setState(() {
+              final entity = state.entity;
               _setMarker(state);
-              _setLatLng(state.entity.location.latitude,
-                  state.entity.location.longitude);
+              _setLatLng(entity.location.latitude, entity.location.longitude);
               _animateToPosition(state.entity.address);
             });
           });

--- a/lib/features/location/presentation/widgets/select_other_location_widget.dart
+++ b/lib/features/location/presentation/widgets/select_other_location_widget.dart
@@ -16,7 +16,6 @@ class SelectOtherLocationWidget extends StatelessWidget {
         if (state is GetPositionLoading) {
           return const CircularProgressIndicator();
         }
-
         return TextButton(
           onPressed: () {
             cubit.getPosition();


### PR DESCRIPTION
- Removed unnecessary import of `enums.dart` in `di.dart`.
- Simplified `initLocationDi` function by removing the `LocationPurpose` parameter and handling state checks internally.
- Updated `RouteGenerator` to call `initLocationDi` without passing `LocationPurpose` and set the purpose directly in the `LocationCubit`.
- Cleaned up `confirm_payment_cubit.dart` by removing extra blank lines.
- Modified `location_cubit.dart` to allow setting the `LocationPurpose` after initialization.
- Updated `select_location_view.dart` to conditionally show the skip button based on the `LocationPurpose`.
- Enhanced `map_view_body.dart` to initialize the map with the current position if available.
- Removed redundant state check in `select_other_location_widget.dart`.