### PR TITLE
Add Account Feature Data & Domain Layers Implementations ✅

### DIFF
--- a/lib/features/account/data/api/account_api_service.dart
+++ b/lib/features/account/data/api/account_api_service.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+import 'package:groceries_app/core/data/models/base_response.dart';
+import 'package:groceries_app/core/network/api_constants.dart';
+import 'package:groceries_app/features/account/data/models/profile_response.dart';
+import 'package:retrofit/retrofit.dart';
+
+part 'account_api_service.g.dart';
+
+@RestApi(baseUrl: ApiConstants.baseUrl)
+abstract class AccountApiService {
+  factory AccountApiService(Dio dio, {String? baseUrl}) = _AccountApiService;
+
+  @POST('user/logout')
+  Future<BaseResponse> logout();
+
+  @GET('user/')
+  Future<ProfileResponse> getProfile();
+}

--- a/lib/features/account/data/api/account_api_service.g.dart
+++ b/lib/features/account/data/api/account_api_service.g.dart
@@ -1,0 +1,106 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_api_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+
+class _AccountApiService implements AccountApiService {
+  _AccountApiService(
+    this._dio, {
+    this.baseUrl,
+  }) {
+    baseUrl ??= 'http://192.168.1.117:8080/';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<BaseResponse> logout() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio
+        .fetch<Map<String, dynamic>>(_setStreamType<BaseResponse>(Options(
+      method: 'POST',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              'user/logout',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = BaseResponse.fromJson(_result.data!);
+    return _value;
+  }
+
+  @override
+  Future<ProfileResponse> getProfile() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio
+        .fetch<Map<String, dynamic>>(_setStreamType<ProfileResponse>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              'user/',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = ProfileResponse.fromJson(_result.data!);
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/features/account/data/data_source/account_data_source.dart
+++ b/lib/features/account/data/data_source/account_data_source.dart
@@ -1,0 +1,25 @@
+import 'package:groceries_app/core/data/models/base_response.dart';
+import 'package:groceries_app/features/account/data/api/account_api_service.dart';
+import 'package:groceries_app/features/account/data/models/profile_response.dart';
+
+abstract class AccountDataSource {
+  Future<BaseResponse> logout();
+
+  Future<ProfileResponse> getProfile();
+}
+
+class AccountDataSourceImpl implements AccountDataSource {
+  final AccountApiService _accountApiService;
+
+  AccountDataSourceImpl(this._accountApiService);
+
+  @override
+  Future<BaseResponse> logout() async {
+    return await _accountApiService.logout();
+  }
+
+  @override
+  Future<ProfileResponse> getProfile() async {
+    return await _accountApiService.getProfile();
+  }
+}

--- a/lib/features/account/data/models/profile_response.dart
+++ b/lib/features/account/data/models/profile_response.dart
@@ -1,0 +1,16 @@
+import 'package:groceries_app/core/data/models/base_response.dart';
+import 'package:groceries_app/core/data/models/user/user_response.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'profile_response.g.dart';
+
+@JsonSerializable(createToJson: false)
+class ProfileResponse extends BaseResponse {
+  @JsonKey(name: 'data')
+  final UserResponse? user;
+
+  ProfileResponse({required super.message, required this.user});
+
+  factory ProfileResponse.fromJson(Map<String, dynamic> json) =>
+      _$ProfileResponseFromJson(json);
+}

--- a/lib/features/account/data/models/profile_response.g.dart
+++ b/lib/features/account/data/models/profile_response.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'profile_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ProfileResponse _$ProfileResponseFromJson(Map<String, dynamic> json) =>
+    ProfileResponse(
+      message: json['message'] as String,
+      user: json['data'] == null
+          ? null
+          : UserResponse.fromJson(json['data'] as Map<String, dynamic>),
+    );

--- a/lib/features/account/data/repo/account_repo_impl.dart
+++ b/lib/features/account/data/repo/account_repo_impl.dart
@@ -1,0 +1,37 @@
+import 'package:dartz/dartz.dart';
+import 'package:groceries_app/core/data/mapper/user_mapper.dart';
+import 'package:groceries_app/core/domain/entities/user_entity.dart';
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/core/network/error_handler.dart';
+import 'package:groceries_app/core/network/failure.dart';
+import 'package:groceries_app/features/account/data/data_source/account_data_source.dart';
+import 'package:groceries_app/features/account/domain/repo/account_repo.dart';
+
+class AccountRepositoryImpl implements AccountRepository {
+  final AccountDataSource _accountDataSource;
+
+  AccountRepositoryImpl(this._accountDataSource);
+
+  @override
+  ResultFuture<UserEntity> getProfile() async {
+    try {
+      final response = await _accountDataSource.getProfile();
+      if (response.user == null) {
+        return Left(Failure.apiInternalError(response.message));
+      }
+      return Right(response.user!.toUserEntity());
+    } catch (error) {
+      return Left(ErrorHandler.handle(error).failure);
+    }
+  }
+
+  @override
+  ResultFuture<String> logout() async {
+    try {
+      final response = await _accountDataSource.logout();
+      return Right(response.message);
+    } catch (error) {
+      return Left(ErrorHandler.handle(error).failure);
+    }
+  }
+}

--- a/lib/features/account/domain/repo/account_repo.dart
+++ b/lib/features/account/domain/repo/account_repo.dart
@@ -1,0 +1,9 @@
+import 'package:groceries_app/core/domain/entities/user_entity.dart';
+import 'package:groceries_app/core/network/api_result.dart';
+
+abstract class AccountRepository {
+
+  ResultFuture<String> logout();
+
+  ResultFuture<UserEntity> getProfile();
+}

--- a/lib/features/account/domain/usecase/get_profile_usecase.dart
+++ b/lib/features/account/domain/usecase/get_profile_usecase.dart
@@ -1,0 +1,13 @@
+import 'package:groceries_app/core/domain/entities/user_entity.dart';
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/core/utils/base_usecase.dart';
+import 'package:groceries_app/features/account/domain/repo/account_repo.dart';
+
+class GetProfileUseCase extends BaseUseCase<void, UserEntity> {
+  final AccountRepository _accountRepository;
+  GetProfileUseCase(this._accountRepository);
+  @override
+  ResultFuture<UserEntity> execute([void input]) {
+    return _accountRepository.getProfile();
+  }
+}

--- a/lib/features/account/domain/usecase/logout_usecase.dart
+++ b/lib/features/account/domain/usecase/logout_usecase.dart
@@ -1,0 +1,12 @@
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/core/utils/base_usecase.dart';
+import 'package:groceries_app/features/account/domain/repo/account_repo.dart';
+
+class LogoutUseCase extends BaseUseCase<void, String> {
+  final AccountRepository _accountRepository;
+  LogoutUseCase(this._accountRepository);
+  @override
+  ResultFuture<String> execute([void input]) {
+    return _accountRepository.logout();
+  }
+}

--- a/lib/features/product_details/data/api/product_details_api_service.dart
+++ b/lib/features/product_details/data/api/product_details_api_service.dart
@@ -13,5 +13,4 @@ abstract class ProductDetailsApiService {
   Future<ProductDetailsResponse> getProductDetails(
     @Path('productId') String productId,
   );
-
 }


### PR DESCRIPTION
- Created `AccountApiService` and its generated implementation using Retrofit to handle account-related API calls.
- Implemented `AccountDataSource` and `AccountDataSourceImpl` to abstract API service calls for account operations.
- Added `ProfileResponse` model and its generated JSON serialization code.
- Implemented `AccountRepositoryImpl` to handle data mapping and error handling for account-related operations.
- Defined `AccountRepository` interface to abstract repository methods.
- Created `GetProfileUseCase` and `LogoutUseCase` to handle profile retrieval and logout operations respectively.
- Updated `ProductDetailsApiService` to remove an unnecessary newline.