### PR TITLE
Finish forget password feature with DI and routing

### DIFF
--- a/lib/core/di/di.dart
+++ b/lib/core/di/di.dart
@@ -56,6 +56,14 @@ import 'package:groceries_app/features/explore/presentation/cubit/explore_cubit.
 import 'package:groceries_app/features/favorites/domain/usecases/add_all_to_cart_usecase.dart';
 import 'package:groceries_app/features/favorites/domain/usecases/get_favorite_usecase.dart';
 import 'package:groceries_app/features/favorites/presentation/cubit/favorite_cubit.dart';
+import 'package:groceries_app/features/forget_password/data/api/forget_password_api_service.dart';
+import 'package:groceries_app/features/forget_password/data/data_source/reset_password_data_source.dart';
+import 'package:groceries_app/features/forget_password/data/repo/forget_password_repo_impl.dart';
+import 'package:groceries_app/features/forget_password/domain/repo/forget_password_repo.dart';
+import 'package:groceries_app/features/forget_password/domain/usecases/reset_password_usecase.dart';
+import 'package:groceries_app/features/forget_password/domain/usecases/send_verification_code_usecase.dart';
+import 'package:groceries_app/features/forget_password/domain/usecases/verify_email_usecase.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
 import 'package:groceries_app/features/home/presentation/provider/home_controller.dart';
 import 'package:groceries_app/features/location/data/api/location_api_service.dart';
 import 'package:groceries_app/features/location/data/api/update_address_api_service.dart';

--- a/lib/core/di/di.main.dart
+++ b/lib/core/di/di.main.dart
@@ -274,6 +274,39 @@ initChangePasswordDi() {
   }
 }
 
+void initForgetPasswordDi() {
+  if (!getIt.isRegistered<ForgetPasswordCubit>()) {
+    getIt
+      ..registerLazySingleton<ForgetPasswordApiService>(
+          () => ForgetPasswordApiService(DioFactory.getDio()))
+      ..registerLazySingleton<ForgetPasswordDataSource>(
+          () => ForgetPasswordDataSourceImpl(getIt()))
+      ..registerLazySingleton<ForgetPasswordRepository>(
+          () => ForgetPasswordRepositoryImpl(getIt()))
+      ..registerLazySingleton<SendEmailVerificationCodeUseCase>(
+          () => SendEmailVerificationCodeUseCase(getIt()))
+      ..registerLazySingleton<VerifyEmailUseCase>(
+          () => VerifyEmailUseCase(getIt()))
+      ..registerLazySingleton<ResetPasswordUseCase>(
+          () => ResetPasswordUseCase(getIt()))
+      ..registerLazySingleton<ForgetPasswordCubit>(
+          () => ForgetPasswordCubit(getIt(), getIt(), getIt(), getIt()));
+  }
+}
+
+void unregisterForgetPasswordDi() {
+  if (getIt.isRegistered<ForgetPasswordCubit>()) {
+    getIt
+      ..unregister<ForgetPasswordCubit>()
+      ..unregister<ResetPasswordUseCase>()
+      ..unregister<VerifyEmailUseCase>()
+      ..unregister<SendEmailVerificationCodeUseCase>()
+      ..unregister<ForgetPasswordRepository>()
+      ..unregister<ForgetPasswordDataSource>()
+      ..unregister<ForgetPasswordApiService>();
+  }
+}
+
 Future<void> resetDis() async {
   await getIt.reset();
   await initDi();

--- a/lib/core/routes/routes_manager.dart
+++ b/lib/core/routes/routes_manager.dart
@@ -19,6 +19,7 @@ import 'package:groceries_app/features/checkout/presentation/views/confirm_payme
 import 'package:groceries_app/features/explore/presentation/cubit/explore_cubit.dart';
 import 'package:groceries_app/features/explore/presentation/views/category_products_view.dart';
 import 'package:groceries_app/features/favorites/presentation/cubit/favorite_cubit.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
 import 'package:groceries_app/features/forget_password/presentation/views/forget_password_view.dart';
 import 'package:groceries_app/features/forget_password/presentation/views/reset_password_view.dart';
 import 'package:groceries_app/features/forget_password/presentation/views/verify_email_view.dart';

--- a/lib/core/routes/routes_manager.main.dart
+++ b/lib/core/routes/routes_manager.main.dart
@@ -252,8 +252,12 @@ abstract class RouteGenerator {
       GoRoute(
         path: Routes.forgetPassword,
         pageBuilder: (context, state) {
+          initForgetPasswordDi();
           return CustomSlideTransition(
-            child: const ForgetPasswordView(),
+            child: BlocProvider<ForgetPasswordCubit>(
+              create: (context) => getIt(),
+              child: const ForgetPasswordView(),
+            ),
           );
         },
       ),
@@ -261,7 +265,10 @@ abstract class RouteGenerator {
         path: Routes.verifyEmail,
         pageBuilder: (context, state) {
           return CustomSlideTransition(
-            child: const VerifyEmailView(),
+            child: BlocProvider<ForgetPasswordCubit>.value(
+              value: getIt(),
+              child: const VerifyEmailView(),
+            ),
           );
         },
       ),
@@ -269,7 +276,10 @@ abstract class RouteGenerator {
         path: Routes.resetPassword,
         pageBuilder: (context, state) {
           return CustomSlideTransition(
-            child: const ResetPasswordView(),
+            child: BlocProvider<ForgetPasswordCubit>.value(
+              value: getIt(),
+              child: const ResetPasswordView(),
+            ),
           );
         },
       ),

--- a/lib/core/utils/app_preferences.dart
+++ b/lib/core/utils/app_preferences.dart
@@ -8,7 +8,7 @@ class AppPreferences {
   final SharedPreferences _sharedPreferences;
   AppPreferences(this._sharedPreferences);
 
-  void setUserAccessToken(String token) async {
+  Future setUserAccessToken(String token) async {
     await _sharedPreferences.setString(userAccessToken, token);
   }
 
@@ -16,7 +16,7 @@ class AppPreferences {
     return _sharedPreferences.getString(userAccessToken);
   }
 
-  void setUserRefreshToken(String token) async {
+  Future setUserRefreshToken(String token) async {
     await _sharedPreferences.setString(userRefreshToken, token);
   }
 

--- a/lib/features/forget_password/data/api/forget_password_api_service.dart
+++ b/lib/features/forget_password/data/api/forget_password_api_service.dart
@@ -16,7 +16,7 @@ abstract class ForgetPasswordApiService {
   @POST('password/send-code')
   Future<OTPResponse> sendEmailVerificationCode(@Field() String email);
 
-  @POST('password/send-code')
+  @POST('password/verify-email')
   Future<OTPResponse> verifyEmail(@Body() VerifyOTPRequest verifyOTPRequest);
 
   @POST('password/reset')

--- a/lib/features/forget_password/data/api/forget_password_api_service.g.dart
+++ b/lib/features/forget_password/data/api/forget_password_api_service.g.dart
@@ -62,7 +62,7 @@ class _ForgetPasswordApiService implements ForgetPasswordApiService {
     )
             .compose(
               _dio.options,
-              'password/send-code',
+              'password/verify-email',
               queryParameters: queryParameters,
               data: _data,
             )

--- a/lib/features/forget_password/domain/usecases/send_verification_code_usecase.dart
+++ b/lib/features/forget_password/domain/usecases/send_verification_code_usecase.dart
@@ -3,10 +3,10 @@ import 'package:groceries_app/core/network/api_result.dart';
 import 'package:groceries_app/core/utils/base_usecase.dart';
 import 'package:groceries_app/features/forget_password/domain/repo/forget_password_repo.dart';
 
-class SendVerificationCodeUseCase extends BaseUseCase<String, OTPEntity> {
+class SendEmailVerificationCodeUseCase extends BaseUseCase<String, OTPEntity> {
   final ForgetPasswordRepository _forgetPasswordRepository;
 
-  SendVerificationCodeUseCase(this._forgetPasswordRepository);
+  SendEmailVerificationCodeUseCase(this._forgetPasswordRepository);
 
   @override
   ResultFuture<OTPEntity> execute(String input) async {

--- a/lib/features/forget_password/presentation/cubit/forget_password_cubit.dart
+++ b/lib/features/forget_password/presentation/cubit/forget_password_cubit.dart
@@ -1,0 +1,78 @@
+import 'package:bloc/bloc.dart';
+import 'package:groceries_app/core/di/di.dart';
+import 'package:groceries_app/core/network/dio_factory.dart';
+import 'package:groceries_app/core/utils/app_preferences.dart';
+import 'package:groceries_app/core/utils/extensions.dart';
+import 'package:groceries_app/features/auth/domain/entities/auth_entity.dart';
+import 'package:groceries_app/features/forget_password/domain/usecases/reset_password_usecase.dart';
+import 'package:groceries_app/features/forget_password/domain/usecases/send_verification_code_usecase.dart';
+import 'package:groceries_app/features/forget_password/domain/usecases/verify_email_usecase.dart';
+
+part 'forget_password_state.dart';
+
+class ForgetPasswordCubit extends Cubit<ForgetPasswordState> {
+  ForgetPasswordCubit(
+    this._emailVerificationCodeUseCase,
+    this._verifyEmailUseCase,
+    this._resetPasswordUseCase,
+    this._appPreferences,
+  ) : super(ForgetPasswordInitial());
+
+  final SendEmailVerificationCodeUseCase _emailVerificationCodeUseCase;
+  final VerifyEmailUseCase _verifyEmailUseCase;
+  final ResetPasswordUseCase _resetPasswordUseCase;
+  final AppPreferences _appPreferences;
+
+  late final String verificationId;
+
+  void sendEmailVerificationCode(String email) async {
+    emit(ForgetPasswordLoading());
+    final result = await _emailVerificationCodeUseCase.execute(email);
+    result.fold(
+      (failure) => emit(ForgetPasswordError(failure.message)),
+      (otpEntity) {
+        logInfo(otpEntity.verificationId);
+        verificationId = otpEntity.verificationId;
+        emit(ForgetPasswordSuccess());
+      },
+    );
+  }
+
+  void verifyEmail(String code) async {
+    emit(ForgetPasswordLoading());
+    final result = await _verifyEmailUseCase.execute(VerifyEmailUseCaseInput(
+      verificationId: verificationId,
+      code: code,
+    ));
+    result.fold(
+      (failure) => emit(ForgetPasswordError(failure.message)),
+      (otpEntity) => emit(ForgetPasswordSuccess<String>(otpEntity.message)),
+    );
+  }
+
+  void resetPassword(String password) async {
+    emit(ForgetPasswordLoading());
+    final result =
+        await _resetPasswordUseCase.execute(ResetPasswordUseCaseInput(
+      password: password,
+      verificationId: verificationId,
+    ));
+    result.fold((failure) => emit(ForgetPasswordError(failure.message)),
+        (authEntity) async {
+      await _setUserTokens(authEntity);
+      emit(ForgetPasswordSuccess<AuthEntity>(authEntity));
+    });
+  }
+
+  _setUserTokens(AuthEntity entity) async {
+    DioFactory.setTokenIntoHeader(entity.accessToken);
+    await _appPreferences.setUserAccessToken(entity.accessToken);
+    await _appPreferences.setUserRefreshToken(entity.refreshToken);
+  }
+
+  @override
+  Future<void> close() {
+    unregisterForgetPasswordDi();
+    return super.close();
+  }
+}

--- a/lib/features/forget_password/presentation/cubit/forget_password_state.dart
+++ b/lib/features/forget_password/presentation/cubit/forget_password_state.dart
@@ -1,0 +1,18 @@
+part of 'forget_password_cubit.dart';
+
+sealed class ForgetPasswordState {}
+
+final class ForgetPasswordInitial extends ForgetPasswordState {}
+
+final class ForgetPasswordLoading extends ForgetPasswordState {}
+
+final class ForgetPasswordSuccess<T> extends ForgetPasswordState {
+  final T? data;
+  ForgetPasswordSuccess([this.data]);
+}
+
+final class ForgetPasswordError extends ForgetPasswordState {
+  final String error;
+
+  ForgetPasswordError(this.error);
+}

--- a/lib/features/forget_password/presentation/views/forget_password_listener.dart
+++ b/lib/features/forget_password/presentation/views/forget_password_listener.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:groceries_app/core/widgets/custom_snackbar.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
+
+class ForgetPasswordListener extends StatelessWidget {
+  const ForgetPasswordListener(
+      {super.key,
+      required this.child,
+      this.onLoading,
+      this.onSuccess,
+      this.onError});
+
+  final Function? onLoading;
+  final Function(dynamic data)? onSuccess;
+  final Function(String error)? onError;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ForgetPasswordCubit, ForgetPasswordState>(
+      listener: (context, state) {
+        switch (state) {
+          case ForgetPasswordLoading():
+            onLoading?.call();
+            break;
+          case ForgetPasswordSuccess():
+            onSuccess?.call(state.data);
+            break;
+          case ForgetPasswordError():
+            if (onError == null) {
+              showSnackBar(context, text: state.error);
+            } else {
+              onError?.call(state.error);
+            }
+            break;
+          default:
+            break;
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/lib/features/forget_password/presentation/views/forget_password_view.dart
+++ b/lib/features/forget_password/presentation/views/forget_password_view.dart
@@ -1,29 +1,36 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:groceries_app/core/res/color_manager.dart';
 import 'package:groceries_app/core/res/strings_manager.dart';
 import 'package:groceries_app/core/res/styles_manager.dart';
 import 'package:groceries_app/core/widgets/custom_back_button.dart';
+import 'package:groceries_app/features/forget_password/presentation/views/forget_password_listener.dart';
 import 'package:groceries_app/features/forget_password/presentation/widgets/forget_password_view_body.dart';
+
+import '../../../../core/routes/routes_manager.dart';
 
 class ForgetPasswordView extends StatelessWidget {
   const ForgetPasswordView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        leading: const CustomBackButton(),
-        title: const Text(
-          AppStrings.resetPassword,
-          style: StylesManager.semiBold26,
+    return ForgetPasswordListener(
+      onSuccess: (_) => context.push(Routes.verifyEmail),
+      child: Scaffold(
+        appBar: AppBar(
+          leading: const CustomBackButton(),
+          title: const Text(
+            AppStrings.resetPassword,
+            style: StylesManager.semiBold26,
+          ),
+          bottom: const PreferredSize(
+              preferredSize: Size.fromHeight(1),
+              child: Divider(
+                color: ColorManager.lightGray,
+              )),
         ),
-        bottom: const PreferredSize(
-            preferredSize: Size.fromHeight(1),
-            child: Divider(
-              color: ColorManager.lightGray,
-            )),
+        body: const ForgetPasswordViewBody(),
       ),
-      body: const ForgetPasswordViewBody(),
     );
   }
 }

--- a/lib/features/forget_password/presentation/views/reset_password_view.dart
+++ b/lib/features/forget_password/presentation/views/reset_password_view.dart
@@ -2,7 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:groceries_app/core/res/color_manager.dart';
 import 'package:groceries_app/core/res/strings_manager.dart';
 import 'package:groceries_app/core/res/styles_manager.dart';
+import 'package:groceries_app/core/routes/routes_manager.dart';
+import 'package:groceries_app/core/utils/extensions.dart';
 import 'package:groceries_app/core/widgets/custom_back_button.dart';
+import 'package:groceries_app/features/forget_password/presentation/views/forget_password_listener.dart';
 import 'package:groceries_app/features/forget_password/presentation/widgets/reset_password_view_body.dart';
 
 class ResetPasswordView extends StatelessWidget {
@@ -10,20 +13,23 @@ class ResetPasswordView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        leading: const CustomBackButton(),
-        title: const Text(
-          AppStrings.resetPassword,
-          style: StylesManager.semiBold26,
+    return ForgetPasswordListener(
+      onSuccess: (_) => context.popAllThenPush(Routes.homeRoute),
+      child: Scaffold(
+        appBar: AppBar(
+          leading: const CustomBackButton(),
+          title: const Text(
+            AppStrings.resetPassword,
+            style: StylesManager.semiBold26,
+          ),
+          bottom: const PreferredSize(
+              preferredSize: Size.fromHeight(1),
+              child: Divider(
+                color: ColorManager.lightGray,
+              )),
         ),
-        bottom: const PreferredSize(
-            preferredSize: Size.fromHeight(1),
-            child: Divider(
-              color: ColorManager.lightGray,
-            )),
+        body: const ResetPasswordViewBody(),
       ),
-      body: const ResetPasswordViewBody(),
     );
   }
 }

--- a/lib/features/forget_password/presentation/views/verify_email_view.dart
+++ b/lib/features/forget_password/presentation/views/verify_email_view.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:groceries_app/core/res/color_manager.dart';
 import 'package:groceries_app/core/res/strings_manager.dart';
 import 'package:groceries_app/core/res/styles_manager.dart';
+import 'package:groceries_app/core/routes/routes_manager.dart';
 import 'package:groceries_app/core/widgets/custom_back_button.dart';
+import 'package:groceries_app/features/forget_password/presentation/views/forget_password_listener.dart';
 import 'package:groceries_app/features/forget_password/presentation/widgets/verify_email_view_body.dart';
 
 class VerifyEmailView extends StatelessWidget {
@@ -10,20 +13,23 @@ class VerifyEmailView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        leading: const CustomBackButton(),
-        title: const Text(
-          AppStrings.verification,
-          style: StylesManager.semiBold26,
+    return ForgetPasswordListener(
+      onSuccess: (_) => context.push(Routes.resetPassword),
+      child: Scaffold(
+        appBar: AppBar(
+          leading: const CustomBackButton(),
+          title: const Text(
+            AppStrings.verification,
+            style: StylesManager.semiBold26,
+          ),
+          bottom: const PreferredSize(
+              preferredSize: Size.fromHeight(1),
+              child: Divider(
+                color: ColorManager.lightGray,
+              )),
         ),
-        bottom: const PreferredSize(
-            preferredSize: Size.fromHeight(1),
-            child: Divider(
-              color: ColorManager.lightGray,
-            )),
+        body: const VerifyEmailViewBody(),
       ),
-      body: const VerifyEmailViewBody(),
     );
   }
 }

--- a/lib/features/forget_password/presentation/widgets/forget_password_feature_button.dart
+++ b/lib/features/forget_password/presentation/widgets/forget_password_feature_button.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:groceries_app/core/res/styles_manager.dart';
+import 'package:groceries_app/core/widgets/custom_button_widget.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
+
+class ForgetPasswordFeatureButton extends StatelessWidget {
+  const ForgetPasswordFeatureButton(
+      {super.key, required this.text, required this.onPressed});
+
+  final String text;
+  final Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ForgetPasswordCubit, ForgetPasswordState>(
+      builder: (context, state) {
+        return CustomElevatedButtonWidget(
+          isLoading: state is ForgetPasswordLoading,
+          onPressed: onPressed,
+          child: Text(
+            text,
+            style: StylesManager.semiBold18,
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/features/forget_password/presentation/widgets/forget_password_view_body.dart
+++ b/lib/features/forget_password/presentation/widgets/forget_password_view_body.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:form_validator/form_validator.dart';
-import 'package:go_router/go_router.dart';
 import 'package:groceries_app/core/res/strings_manager.dart';
 import 'package:groceries_app/core/res/styles_manager.dart';
 import 'package:groceries_app/core/res/values_manager.dart';
-import 'package:groceries_app/core/routes/routes_manager.dart';
-import 'package:groceries_app/core/widgets/custom_button_widget.dart';
 import 'package:groceries_app/core/widgets/custom_form_field.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
+import 'package:groceries_app/features/forget_password/presentation/widgets/forget_password_feature_button.dart';
 
 class ForgetPasswordViewBody extends StatefulWidget {
   const ForgetPasswordViewBody({super.key});
@@ -17,9 +17,12 @@ class ForgetPasswordViewBody extends StatefulWidget {
 
 class _ForgetPasswordViewBodyState extends State<ForgetPasswordViewBody> {
   late final GlobalKey<FormState> _formKey;
+  late final TextEditingController _controller;
+
   @override
   void initState() {
     _formKey = GlobalKey<FormState>();
+    _controller = TextEditingController();
     super.initState();
   }
 
@@ -38,20 +41,23 @@ class _ForgetPasswordViewBodyState extends State<ForgetPasswordViewBody> {
                   style: StylesManager.bold18),
               const SizedBox(height: AppSize.s20),
               CustomTextFormField(
+                controller: _controller,
                 validator: ValidationBuilder().email().build(),
                 labelText: AppStrings.email,
               ),
               const SizedBox(height: AppSize.s20),
-              CustomElevatedButtonWidget(
-                  onPressed: () {
-                    if (!_formKey.currentState!.validate()) {
-                      context.push(Routes.verifyEmail);
-                    }
-                  },
-                  child: const Text(
-                    AppStrings.sendVerificationCode,
-                    style: StylesManager.semiBold18,
-                  )),
+              ForgetPasswordFeatureButton(
+                text: AppStrings.sendVerificationCode,
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    context
+                        .read<ForgetPasswordCubit>()
+                        .sendEmailVerificationCode(
+                          _controller.text.trim(),
+                        );
+                  }
+                },
+              ),
             ],
           ),
         ),

--- a/lib/features/forget_password/presentation/widgets/reset_password_view_body.dart
+++ b/lib/features/forget_password/presentation/widgets/reset_password_view_body.dart
@@ -1,12 +1,31 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:groceries_app/core/res/strings_manager.dart';
 import 'package:groceries_app/core/res/styles_manager.dart';
 import 'package:groceries_app/core/res/values_manager.dart';
-import 'package:groceries_app/core/widgets/custom_button_widget.dart';
 import 'package:groceries_app/core/widgets/password_field_widget.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
+import 'package:groceries_app/features/forget_password/presentation/widgets/forget_password_feature_button.dart';
 
-class ResetPasswordViewBody extends StatelessWidget {
+class ResetPasswordViewBody extends StatefulWidget {
   const ResetPasswordViewBody({super.key});
+
+  @override
+  State<ResetPasswordViewBody> createState() => _ResetPasswordViewBodyState();
+}
+
+class _ResetPasswordViewBodyState extends State<ResetPasswordViewBody> {
+  late final TextEditingController _newPasswordController;
+  late final TextEditingController _confirmPasswordController;
+  late final GlobalKey<FormState> _formKey;
+
+  @override
+  void initState() {
+    _newPasswordController = TextEditingController();
+    _confirmPasswordController = TextEditingController();
+    _formKey = GlobalKey<FormState>();
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -14,24 +33,43 @@ class ResetPasswordViewBody extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsetsDirectional.symmetric(
             horizontal: AppPadding.p20, vertical: AppPadding.p18),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            const Text(AppStrings.resetPassword, style: StylesManager.bold18),
-            const SizedBox(height: AppSize.s20),
-            const PasswordFieldWidget(labelText: AppStrings.newPassword),
-            const SizedBox(height: AppSize.s20),
-            const PasswordFieldWidget(labelText: AppStrings.confirmPassword),
-            const SizedBox(height: AppSize.s20),
-            CustomElevatedButtonWidget(
-                onPressed: () {},
-                child: const Text(
-                  AppStrings.resetPassword,
-                  style: StylesManager.semiBold18,
-                )),
-          ],
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text(AppStrings.resetPassword, style: StylesManager.bold18),
+              const SizedBox(height: AppSize.s20),
+              PasswordFieldWidget(
+                  controller: _newPasswordController,
+                  labelText: AppStrings.newPassword),
+              const SizedBox(height: AppSize.s20),
+              PasswordFieldWidget(
+                  controller: _confirmPasswordController,
+                  validator: _confirmPasswordValidator,
+                  labelText: AppStrings.confirmPassword),
+              const SizedBox(height: AppSize.s20),
+              ForgetPasswordFeatureButton(
+                text: AppStrings.resetPassword,
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    context.read<ForgetPasswordCubit>().resetPassword(
+                          _newPasswordController.text,
+                        );
+                  }
+                },
+              ),
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  String? _confirmPasswordValidator(String? value) {
+    if (_newPasswordController.text != value) {
+      return AppStrings.passwordMismatch;
+    }
+    return null;
   }
 }

--- a/lib/features/forget_password/presentation/widgets/verify_email_view_body.dart
+++ b/lib/features/forget_password/presentation/widgets/verify_email_view_body.dart
@@ -1,14 +1,28 @@
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:groceries_app/core/res/strings_manager.dart';
 import 'package:groceries_app/core/res/styles_manager.dart';
 import 'package:groceries_app/core/res/values_manager.dart';
-import 'package:groceries_app/core/routes/routes_manager.dart';
 import 'package:groceries_app/core/widgets/code_input_widget.dart';
-import 'package:groceries_app/core/widgets/custom_button_widget.dart';
+import 'package:groceries_app/core/widgets/custom_snackbar.dart';
+import 'package:groceries_app/features/forget_password/presentation/cubit/forget_password_cubit.dart';
+import 'package:groceries_app/features/forget_password/presentation/widgets/forget_password_feature_button.dart';
 
-class VerifyEmailViewBody extends StatelessWidget {
+class VerifyEmailViewBody extends StatefulWidget {
   const VerifyEmailViewBody({super.key});
+
+  @override
+  State<VerifyEmailViewBody> createState() => _VerifyEmailViewBodyState();
+}
+
+class _VerifyEmailViewBodyState extends State<VerifyEmailViewBody> {
+  late final TextEditingController _controller;
+
+  @override
+  void initState() {
+    _controller = TextEditingController();
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,16 +35,20 @@ class VerifyEmailViewBody extends StatelessWidget {
           children: [
             const Text(AppStrings.enterEmailCode, style: StylesManager.bold18),
             const SizedBox(height: AppSize.s20),
-            const CodeInputWidget(),
+            CodeInputWidget(controller: _controller),
             const SizedBox(height: AppSize.s20),
-            CustomElevatedButtonWidget(
-                onPressed: () {
-                  context.push(Routes.resetPassword);
-                },
-                child: const Text(
-                  AppStrings.verify,
-                  style: StylesManager.semiBold18,
-                )),
+            ForgetPasswordFeatureButton(
+              text: AppStrings.verify,
+              onPressed: () {
+                if (_controller.text.length < 6) {
+                  showSnackBar(context, text: AppStrings.codeIsNotCompleted);
+                } else {
+                  context
+                      .read<ForgetPasswordCubit>()
+                      .verifyEmail(_controller.text);
+                }
+              },
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
- Integrated forget password feature including API services, data sources, repositories, use cases, and presentation layer with Cubit for state management.
- Added dependency injection setup for forget password feature in di.dart and di.main.dart.
- Updated routes_manager.dart and routes_manager.main.dart to include routes and DI initialization for forget password views.
- Modified AppPreferences to return Future for setUserAccessToken and setUserRefreshToken methods.
- Corrected API endpoint in ForgetPasswordApiService for email verification.
- Renamed SendVerificationCodeUseCase to SendEmailVerificationCodeUseCase.
- Added ForgetPasswordCubit for managing forget password states and actions.
- Created ForgetPasswordListener for handling state changes in views.
- Updated forget password views to use ForgetPasswordListener and ForgetPasswordFeatureButton for handling actions and state.