### PR TITLE
Add Order Data and Domain Layers

### DIFF
--- a/lib/core/utils/enums.dart
+++ b/lib/core/utils/enums.dart
@@ -18,3 +18,8 @@ enum OrderStatus {
   shipped,
   delivered,
 }
+
+enum OrderPaymentStatus {
+  pending,
+  paid,
+}

--- a/lib/core/utils/extensions.dart
+++ b/lib/core/utils/extensions.dart
@@ -90,12 +90,21 @@ extension ScrollControllerExtension on ScrollController {
   }
 }
 
-extension GetOnlyNewItems<T> on List<T> {
-  List<T> getOnlyNewItems(Iterable<T> newItems) {
+extension IterableExensions<T> on Iterable<T> {
+  Iterable<T> getOnlyNewItems(Iterable<T> newItems) {
     final existingItems = Set<T>.from(this);
 
     newItems = newItems.where((element) => !existingItems.contains(element));
     return newItems.toList();
+  }
+
+  T? firstWhereOrNull(bool Function(T element) test) {
+    for (var element in this) {
+      if (test(element)) {
+        return element;
+      }
+    }
+    return null;
   }
 
   int get nextPage => (length ~/ 8) + 1;

--- a/lib/features/orders/data/api/orders_api_service.dart
+++ b/lib/features/orders/data/api/orders_api_service.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+import 'package:groceries_app/core/network/api_constants.dart';
+import 'package:groceries_app/features/orders/data/models/order_response.dart';
+import 'package:groceries_app/features/orders/data/models/orders_response.dart';
+import 'package:retrofit/http.dart';
+
+part 'orders_api_service.g.dart';
+
+@RestApi(baseUrl: ApiConstants.baseUrl)
+abstract class OrdersApiService {
+  factory OrdersApiService(Dio dio, {String? baseUrl}) = _OrdersApiService;
+
+  @GET('/orders')
+  Future<OrdersResponse> getOrders();
+
+  @DELETE('/orders/{orderId}')
+  Future<OrderResponse> cancelOrder(@Path('orderId') int orderId);
+}

--- a/lib/features/orders/data/api/orders_api_service.g.dart
+++ b/lib/features/orders/data/api/orders_api_service.g.dart
@@ -1,0 +1,106 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'orders_api_service.dart';
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element
+
+class _OrdersApiService implements OrdersApiService {
+  _OrdersApiService(
+    this._dio, {
+    this.baseUrl,
+  }) {
+    baseUrl ??= 'http://192.168.1.117:8080/';
+  }
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  @override
+  Future<OrdersResponse> getOrders() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio
+        .fetch<Map<String, dynamic>>(_setStreamType<OrdersResponse>(Options(
+      method: 'GET',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/orders',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = OrdersResponse.fromJson(_result.data!);
+    return _value;
+  }
+
+  @override
+  Future<OrderResponse> cancelOrder(int orderId) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _result = await _dio
+        .fetch<Map<String, dynamic>>(_setStreamType<OrderResponse>(Options(
+      method: 'DELETE',
+      headers: _headers,
+      extra: _extra,
+    )
+            .compose(
+              _dio.options,
+              '/orders/${orderId}',
+              queryParameters: queryParameters,
+              data: _data,
+            )
+            .copyWith(
+                baseUrl: _combineBaseUrls(
+              _dio.options.baseUrl,
+              baseUrl,
+            ))));
+    final _value = OrderResponse.fromJson(_result.data!);
+    return _value;
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(
+    String dioBaseUrl,
+    String? baseUrl,
+  ) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}

--- a/lib/features/orders/data/data_source/orders_data_source.dart
+++ b/lib/features/orders/data/data_source/orders_data_source.dart
@@ -1,0 +1,25 @@
+import 'package:groceries_app/features/orders/data/api/orders_api_service.dart';
+import 'package:groceries_app/features/orders/data/models/order_response.dart';
+import 'package:groceries_app/features/orders/data/models/orders_response.dart';
+
+abstract class OrdersDataSource {
+  Future<OrdersResponse> getOrders();
+
+  Future<OrderResponse> cancelOrder(int orderId);
+}
+
+class OrdersDataSourceImpl implements OrdersDataSource {
+  final OrdersApiService _ordersApiService;
+
+  OrdersDataSourceImpl(this._ordersApiService);
+
+  @override
+  Future<OrdersResponse> getOrders() async {
+    return _ordersApiService.getOrders();
+  }
+
+  @override
+  Future<OrderResponse> cancelOrder(int orderId) async {
+    return _ordersApiService.cancelOrder(orderId);
+  }
+}

--- a/lib/features/orders/data/mappers/order_mapper.dart
+++ b/lib/features/orders/data/mappers/order_mapper.dart
@@ -1,0 +1,42 @@
+import 'package:groceries_app/core/data/mapper/product_mapper.dart';
+import 'package:groceries_app/core/network/api_error_messages.dart';
+import 'package:groceries_app/core/network/failure.dart';
+import 'package:groceries_app/core/utils/enums.dart';
+import 'package:groceries_app/core/utils/extensions.dart';
+import 'package:groceries_app/features/orders/data/models/order_response_model.dart';
+import 'package:groceries_app/features/orders/domain/entities/order_entity.dart';
+
+extension OrderResponseModelMapper on OrderResponseModel {
+  OrderEntity toEntity() {
+    return OrderEntity(
+      orderId: orderId.orZero(),
+      orderDate: DateTime.parse(orderDate.orEmpty()),
+      shippingDate: shippingDate != null ? DateTime.parse(shippingDate!) : null,
+      shippingAddress: shippingAddress.orEmpty(),
+      status: OrderStatus.values.firstWhere(
+          (e) => e.name == status?.toLowerCase(),
+          orElse: () => OrderStatus.processing),
+      paymentMethod: PaymentMethodsEnum.values.firstWhere(
+          (e) => e.name == paymentMethod?.toLowerCase(),
+          orElse: () => PaymentMethodsEnum.cash),
+      paymentStatus: OrderPaymentStatus.values
+          .firstWhereOrNull((e) => e.name == paymentStatus?.toLowerCase()),
+      totalPrice: totalPrice.orZero(),
+      orderItems: orderItems?.map((item) => item.toEntity()).toList() ?? [],
+      paymentLink: paymentLink.orEmpty(),
+    );
+  }
+}
+
+extension OrderItemResponseMapper on OrderItemResponse {
+  OrderItemEntity toEntity() {
+    if (product == null) {
+      throw Failure.apiInternalError(ApiErrorMessages.unknownError);
+    }
+    return OrderItemEntity(
+      orderId: orderId.orZero(),
+      product: product!.toEntity(),
+      quantity: quantity.orZero(),
+    );
+  }
+}

--- a/lib/features/orders/data/models/order_response.dart
+++ b/lib/features/orders/data/models/order_response.dart
@@ -1,0 +1,16 @@
+import 'package:groceries_app/core/data/models/base_response.dart';
+import 'package:groceries_app/features/orders/data/models/order_response_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'order_response.g.dart';
+
+@JsonSerializable(createToJson: false)
+class OrderResponse extends BaseResponse {
+  @JsonKey(name: "data")
+  final OrderResponseModel? order;
+
+  OrderResponse({required this.order, required super.message});
+
+  factory OrderResponse.fromJson(Map<String, dynamic> json) =>
+      _$OrderResponseFromJson(json);
+}

--- a/lib/features/orders/data/models/order_response.g.dart
+++ b/lib/features/orders/data/models/order_response.g.dart
@@ -1,0 +1,15 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'order_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OrderResponse _$OrderResponseFromJson(Map<String, dynamic> json) =>
+    OrderResponse(
+      order: json['data'] == null
+          ? null
+          : OrderResponseModel.fromJson(json['data'] as Map<String, dynamic>),
+      message: json['message'] as String,
+    );

--- a/lib/features/orders/data/models/order_response_model.dart
+++ b/lib/features/orders/data/models/order_response_model.dart
@@ -1,0 +1,48 @@
+import 'package:groceries_app/core/data/models/products_response.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'order_response_model.g.dart';
+
+@JsonSerializable(createToJson: false)
+class OrderResponseModel {
+  final int? orderId;
+  final String? orderDate;
+  final String? shippingDate;
+  final String? shippingAddress;
+  final int? userId;
+  final String? status;
+  final String? paymentMethod;
+  final String? paymentStatus;
+  final double? totalPrice;
+  final List<OrderItemResponse>? orderItems;
+  final String? paymentLink;
+
+  OrderResponseModel(
+      {required this.orderId,
+      required this.orderDate,
+      required this.shippingDate,
+      required this.shippingAddress,
+      required this.userId,
+      required this.status,
+      required this.paymentMethod,
+      required this.paymentStatus,
+      required this.totalPrice,
+      required this.orderItems,
+      required this.paymentLink});
+
+  factory OrderResponseModel.fromJson(Map<String, dynamic> json) =>
+      _$OrderResponseModelFromJson(json);
+}
+
+@JsonSerializable(createToJson: false)
+class OrderItemResponse {
+  final int? orderId;
+  final ProductModel? product;
+  final int? quantity;
+
+  OrderItemResponse(
+      {required this.orderId, required this.product, required this.quantity});
+
+  factory OrderItemResponse.fromJson(Map<String, dynamic> json) =>
+      _$OrderItemResponseFromJson(json);
+}

--- a/lib/features/orders/data/models/order_response_model.g.dart
+++ b/lib/features/orders/data/models/order_response_model.g.dart
@@ -1,0 +1,33 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'order_response_model.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OrderResponseModel _$OrderResponseModelFromJson(Map<String, dynamic> json) =>
+    OrderResponseModel(
+      orderId: (json['orderId'] as num?)?.toInt(),
+      orderDate: json['orderDate'] as String?,
+      shippingDate: json['shippingDate'] as String?,
+      shippingAddress: json['shippingAddress'] as String?,
+      userId: (json['userId'] as num?)?.toInt(),
+      status: json['status'] as String?,
+      paymentMethod: json['paymentMethod'] as String?,
+      paymentStatus: json['paymentStatus'] as String?,
+      totalPrice: (json['totalPrice'] as num?)?.toDouble(),
+      orderItems: (json['orderItems'] as List<dynamic>?)
+          ?.map((e) => OrderItemResponse.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      paymentLink: json['paymentLink'] as String?,
+    );
+
+OrderItemResponse _$OrderItemResponseFromJson(Map<String, dynamic> json) =>
+    OrderItemResponse(
+      orderId: (json['orderId'] as num?)?.toInt(),
+      product: json['product'] == null
+          ? null
+          : ProductModel.fromJson(json['product'] as Map<String, dynamic>),
+      quantity: (json['quantity'] as num?)?.toInt(),
+    );

--- a/lib/features/orders/data/models/orders_response.dart
+++ b/lib/features/orders/data/models/orders_response.dart
@@ -1,0 +1,27 @@
+import 'package:groceries_app/core/data/models/base_response.dart';
+import 'package:groceries_app/features/orders/data/models/order_response_model.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'orders_response.g.dart';
+
+@JsonSerializable(createToJson: false)
+class OrdersResponse extends BaseResponse {
+  final OrdersResponseData? data;
+
+  OrdersResponse({required super.message, required this.data});
+
+  factory OrdersResponse.fromJson(Map<String, dynamic> json) =>
+      _$OrdersResponseFromJson(json);
+}
+
+@JsonSerializable(createToJson: false)
+class OrdersResponseData {
+  @JsonKey(name: "items")
+  final List<OrderResponseModel> orders;
+  final int itemCount;
+
+  OrdersResponseData({required this.orders, required this.itemCount});
+
+  factory OrdersResponseData.fromJson(Map<String, dynamic> json) =>
+      _$OrdersResponseDataFromJson(json);
+}

--- a/lib/features/orders/data/models/orders_response.g.dart
+++ b/lib/features/orders/data/models/orders_response.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'orders_response.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+OrdersResponse _$OrdersResponseFromJson(Map<String, dynamic> json) =>
+    OrdersResponse(
+      message: json['message'] as String,
+      data: json['data'] == null
+          ? null
+          : OrdersResponseData.fromJson(json['data'] as Map<String, dynamic>),
+    );
+
+OrdersResponseData _$OrdersResponseDataFromJson(Map<String, dynamic> json) =>
+    OrdersResponseData(
+      orders: (json['items'] as List<dynamic>)
+          .map((e) => OrderResponseModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      itemCount: (json['itemCount'] as num).toInt(),
+    );

--- a/lib/features/orders/data/repo/orders_repo_impl.dart
+++ b/lib/features/orders/data/repo/orders_repo_impl.dart
@@ -1,0 +1,38 @@
+import 'package:dartz/dartz.dart';
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/core/network/error_handler.dart';
+import 'package:groceries_app/core/network/failure.dart';
+import 'package:groceries_app/features/orders/data/data_source/orders_data_source.dart';
+import 'package:groceries_app/features/orders/data/mappers/order_mapper.dart';
+import 'package:groceries_app/features/orders/domain/entities/order_entity.dart';
+import 'package:groceries_app/features/orders/domain/repo/orders_repo.dart';
+
+class OrderRepositoryImpl extends OrderRepository {
+  final OrdersDataSource _orderDataSource;
+
+  OrderRepositoryImpl(this._orderDataSource);
+
+  @override
+  ResultFuture<List<OrderEntity>> getOrders() async {
+    try {
+      final result = await _orderDataSource.getOrders();
+      if (result.data == null) {
+        return Left(Failure.apiInternalError(result.message));
+      }
+      return Right(
+          result.data!.orders.map((order) => order.toEntity()).toList());
+    } catch (error) {
+      return Left(ErrorHandler.handle(error).failure);
+    }
+  }
+
+  @override
+  ResultFuture<String> cancelOrder(int orderId) async {
+    try {
+      final result = await _orderDataSource.cancelOrder(orderId);
+      return Right(result.message);
+    } catch (error) {
+      return Left(ErrorHandler.handle(error).failure);
+    }
+  }
+}

--- a/lib/features/orders/domain/entities/order_entity.dart
+++ b/lib/features/orders/domain/entities/order_entity.dart
@@ -1,0 +1,40 @@
+import 'package:groceries_app/core/domain/entities/product_entity.dart';
+import 'package:groceries_app/core/utils/enums.dart';
+
+class OrderEntity {
+  final int orderId;
+  final DateTime orderDate;
+  final DateTime? shippingDate;
+  final String shippingAddress;
+  final OrderStatus status;
+  final PaymentMethodsEnum paymentMethod;
+  final OrderPaymentStatus? paymentStatus;
+  final double totalPrice;
+  final List<OrderItemEntity> orderItems;
+  final String? paymentLink;
+
+  OrderEntity({
+    required this.orderId,
+    required this.orderDate,
+    this.shippingDate,
+    required this.shippingAddress,
+    required this.status,
+    required this.paymentMethod,
+    required this.paymentStatus,
+    required this.totalPrice,
+    required this.orderItems,
+    this.paymentLink,
+  });
+}
+
+class OrderItemEntity {
+  final int orderId;
+  final ProductEntity product;
+  final int quantity;
+
+  OrderItemEntity({
+    required this.orderId,
+    required this.product,
+    required this.quantity,
+  });
+}

--- a/lib/features/orders/domain/repo/orders_repo.dart
+++ b/lib/features/orders/domain/repo/orders_repo.dart
@@ -1,0 +1,7 @@
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/features/orders/domain/entities/order_entity.dart';
+
+abstract class OrderRepository {
+  ResultFuture<List<OrderEntity>> getOrders();
+  ResultFuture<String> cancelOrder(int orderId);
+}

--- a/lib/features/orders/domain/usecases/cancel_order_use_case.dart
+++ b/lib/features/orders/domain/usecases/cancel_order_use_case.dart
@@ -1,0 +1,14 @@
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/core/utils/base_usecase.dart';
+import 'package:groceries_app/features/orders/domain/repo/orders_repo.dart';
+
+class CancelOrderUseCase extends BaseUseCase<int, void> {
+  final OrderRepository _orderRepository;
+
+  CancelOrderUseCase(this._orderRepository);
+
+  @override
+  ResultFuture<void> execute(int input) {
+    return _orderRepository.cancelOrder(input);
+  }
+}

--- a/lib/features/orders/domain/usecases/get_orders_use_case.dart
+++ b/lib/features/orders/domain/usecases/get_orders_use_case.dart
@@ -1,0 +1,15 @@
+import 'package:groceries_app/core/network/api_result.dart';
+import 'package:groceries_app/core/utils/base_usecase.dart';
+import 'package:groceries_app/features/orders/domain/entities/order_entity.dart';
+import 'package:groceries_app/features/orders/domain/repo/orders_repo.dart';
+
+class GetOrdersUseCase extends BaseUseCase<void, List<OrderEntity>> {
+  final OrderRepository _orderRepository;
+
+  GetOrdersUseCase(this._orderRepository);
+
+  @override
+  ResultFuture<List<OrderEntity>> execute([void input]) {
+    return _orderRepository.getOrders();
+  }
+}


### PR DESCRIPTION
- Introduce OrderPaymentStatus enum to track payment status.
- Extend IterableExtensions with firstWhereOrNull method.
- Implement OrdersApiService for order-related API calls.
- Create OrdersDataSource and its implementation for data handling.
- Add OrderResponseModel and OrderItemResponse for API response mapping.
- Develop OrderMapper to convert response models to entities.
- Define OrderEntity and OrderItemEntity for domain layer.
- Implement OrderRepository and its methods for data operations.
- Add use cases for getting and canceling orders