### PR TITLE
Switch to flutter_dotenv for environment variables

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,7 +4,17 @@ plugins {
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id "dev.flutter.flutter-gradle-plugin"
 }
-apply from: project(':flutter_config').projectDir.getPath() + "/dotenv.gradle"
+
+
+def dotenvFile = file("../../.env")
+def googleMapsApiKey = ""
+if (dotenvFile.exists()) {
+    dotenvFile.withReader('UTF-8') { reader ->
+        def env = new Properties()
+        env.load(reader)
+        googleMapsApiKey = env.getProperty('GOOGLE_MAPS_API_KEY', "")
+    }
+}
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file("local.properties")
@@ -44,7 +54,7 @@ android {
         versionCode = flutterVersionCode.toInteger()
         versionName = flutterVersionName
         def existingPlaceholders = manifestPlaceholders ?: [:]
-        manifestPlaceholders = existingPlaceholders +  [mapsApiKey: project.env.get("GOOGLE_MAPS_API_KEY")]    
+        manifestPlaceholders = existingPlaceholders + [GOOGLE_MAPS_API_KEY: googleMapsApiKey]
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <application
         android:label="groceries_app"
         android:name="${applicationName}"
@@ -31,11 +34,8 @@
             android:name="flutterEmbedding"
             android:value="2" />
         <meta-data android:name="com.google.android.geo.API_KEY"
-               android:value="${mapsApiKey}"/>
+               android:value="${GOOGLE_MAPS_API_KEY}"/>
     </application>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />    
-    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and
          https://developer.android.com/reference/android/content/Intent#ACTION_PROCESS_TEXT.

--- a/lib/features/location/data/data_source/location_data_source.dart
+++ b/lib/features/location/data/data_source/location_data_source.dart
@@ -1,4 +1,4 @@
-import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:groceries_app/core/network/api_constants.dart';
 import 'package:groceries_app/features/location/data/api/location_api_service.dart';
 import 'package:groceries_app/features/location/data/api/update_address_api_service.dart';
@@ -32,7 +32,7 @@ class LocationDataSourceImpl implements LocationDataSource {
         .getSuggestedPlaces(suggestedPlaceRequest.copyWith(apiKey: _key));
   }
 
-  String get _key => FlutterConfig.get(ApiConstants.googleMapKey);
+  String? get _key => dotenv.env[ApiConstants.googleMapKey];
 
   @override
   Future<PlaceDetailsResponse> getPlaceDetails(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,14 @@
+import 'package:bloc/bloc.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_config/flutter_config.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:groceries_app/app.dart';
 import 'package:groceries_app/bloc_observer.dart';
 import 'package:groceries_app/core/di/di.dart';
-import 'package:bloc/bloc.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initDi();
-  await FlutterConfig.loadEnvVariables();
+  await dotenv.load();
   Bloc.observer = MyBlocObserver();
   runApp(NectarApp());
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -374,14 +374,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.4.0"
-  flutter_config:
+  flutter_dotenv:
     dependency: "direct main"
     description:
-      name: flutter_config
-      sha256: a07e6156bb6e776e29c6357be433155acda87d1dab1a3f787a72091a1b71ffbf
+      name: flutter_dotenv
+      sha256: "9357883bdd153ab78cbf9ffa07656e336b8bbb2b5a3ca596b0b27e119f7c7d77"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "5.1.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -53,7 +53,6 @@ dependencies:
   get_it: ^7.7.0
   intl_phone_number_input: ^0.7.4
   pinput: ^5.0.0
-  flutter_config: ^2.0.2
   google_maps_flutter: ^2.7.0
   material_floating_search_bar_2: ^0.5.0
   geolocator: ^12.0.0
@@ -68,6 +67,7 @@ dependencies:
   webview_flutter: ^4.9.0
   image_picker: ^1.0.0
   timeline_tile: ^2.0.0
+  flutter_dotenv: ^5.1.0
 
 dev_dependencies:
   flutter_test:
@@ -95,6 +95,7 @@ flutter:
     - assets/images/
     - assets/images/nav_bar/
     - assets/json/
+    - .env
   #   - images/a_dot_ham.jpeg
 
   # An image asset can refer to one or more resolution-specific "variants", see


### PR DESCRIPTION
- Replaced `flutter_config` with `flutter_dotenv` for managing environment variables.
- Updated the `build.gradle` to load the `.env` file and retrieve the Google Maps API key.
- Modified the `AndroidManifest.xml` to use the new environment variable.
- Updated the LocationDataSource to use `flutter_dotenv` for accessing the API key.
- Adjusted the `main.dart` to load environment variables using `flutter_dotenv`.
- Updated `pubspec.yaml` and `pubspec.lock` to reflect the dependency change.
- Added necessary permissions in `AndroidManifest.xml` for location access.